### PR TITLE
PN-4492: new start.sh and start-local.sh scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # pn-codegen
 
-## BUILD immagine docker
+## BUILD immagine locale docker
 
 Eseguire il comando `./build.sh` 
 
 
-## Esecuzione container
+## Esecuzione container da immagine locale
 
 Eseguire il comando presente nel file [start-local.sh](start-local.sh) dalla cartella del microservizio per il quale si intende generare i file OpenApi (ad es. pn-delivery).
+
+## Esecuzione container da immagine ufficiale
+
+Posizionarsi nella root folder del progetto per il quale si vuole generare il codice, ad es. pn-delivery.
+
+Eseguire il comando `./mvnw org.apache.maven.plugins:maven-antrun-plugin:run@init-scripts`
+
+E' possibile personalizzare l'esecuzione con i seguenti parametri:
+- pagopa.codegen.skipdownload: se impostato, non verrà scaricato il file [start.sh](start.sh) e verrà utilizzato quello presente localmente al progetto al path `scripts/openapi/generate-code.sh` 
+- pagopa.codegen.skipdownload: se impostato, non verrà eseguito il file `scripts/openapi/generate-code.sh` 
+- pagopa.codegen.version: se impostato, verrà sovrascritto il tag dell'immagine ufficiale di pn-codegend a scaricare ed eseguire; il default è impostato nel `pom.xml` del progetto `pn-parent`.

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Eseguire il comando `./build.sh`
 
 ## Esecuzione container
 
-Eseguire il comando presente nel file [start.sh](start.sh) dalla cartella del microservizio per il quale si intende generare i file OpenApi (ad es. pn-delivery).
+Eseguire il comando presente nel file [start-local.sh](start-local.sh) dalla cartella del microservizio per il quale si intende generare i file OpenApi (ad es. pn-delivery).

--- a/start-local.sh
+++ b/start-local.sh
@@ -1,0 +1,2 @@
+#! /bin/sh
+docker run --rm -it -v ${PWD}:/usr/local/app/microsvc --name=pn-codegen pagopa/pn-codegen

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,78 @@
-#! /bin/sh
-docker run --rm -it -v ${PWD}:/usr/local/app/microsvc --name=pn-codegen pagopa/pn-codegen
+#!/usr/bin/env bash
+    
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+}
+
+usage() {
+      cat <<EOF
+    Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-t <tag>]
+
+    [-h]                      : this help message
+    [-v]                      : verbose mode
+    -t <tag>                  : pn-codegen tag, default to pom.xml "pagopa.codegen.version" value
+    
+EOF
+  exit 1
+}
+
+parse_params() {
+  # default values of variables set from params
+  tag=""
+
+  while :; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -t | --tag) 
+      tag="${2-}"
+      shift
+      ;;
+    -?*) die "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+  done
+
+  args=("$@")
+
+  if [[ -z "${tag-}" ]]; then
+    tag=$(./mvnw help:evaluate -Dexpression=pagopa.codegen.version -q -DforceStdout)
+
+    if [[ "$tag" == "null object or invalid expression" ]]; then
+      echo "    pagopa.codegen.version not found in pom.xml: ${tag}"
+      echo ""
+      echo ""
+      echo ""
+      tag=""
+    fi
+  fi
+
+  # check required params and arguments
+  [[ -z "${tag-}" ]] && usage 
+  return 0
+}
+
+dump_params(){
+  echo ""
+  echo "######      PARAMETERS      ######"
+  echo "##################################"
+  echo "Tag:          ${tag}"
+}
+
+
+# START SCRIPT
+
+current_dir=$(dirname ${BASH_SOURCE[0]})
+cd ${current_dir}
+cd ../..
+
+
+parse_params "$@"
+dump_params
+
+docker run --rm -it -v ${PWD}:/usr/local/app/microsvc --name=pn-codegen ghcr.io/pagopa/pn-codegen:${tag}


### PR DESCRIPTION
- The start-local.sh script will allow a user to run the locally built image 
- The start.sh script will be used by mvn scripts from single microservices projects to generate the OpenApi files by running the github built codegen image.